### PR TITLE
Init FHoudiniBrushInfo(ABrush* InBrushActor)

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniInputObject.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniInputObject.cpp
@@ -1247,6 +1247,11 @@ FHoudiniBrushInfo::FHoudiniBrushInfo()
 }
 
 FHoudiniBrushInfo::FHoudiniBrushInfo(ABrush* InBrushActor)
+	: CachedTransform()
+	, CachedOrigin(ForceInitToZero)
+	, CachedExtent(ForceInitToZero)
+	, CachedBrushType(EBrushType::Brush_Default)
+	, CachedSurfaceHash(0)
 {
 	if (!InBrushActor)
 		return;


### PR DESCRIPTION
Avoids potential uninitialized struct data.
Necessary for us to hit zero warnings.