### PR TITLE
add steamapp suport

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineCommands.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineCommands.cpp
@@ -33,6 +33,7 @@
 #include "HoudiniEngineBakeUtils.h"
 #include "HoudiniEngineEditorUtils.h"
 #include "HoudiniEngineRuntime.h"
+#include "HoudiniRuntimeSettings.h"
 #include "HoudiniAssetActor.h"
 #include "HoudiniAssetComponent.h"
 #include "HoudiniOutputTranslator.h"
@@ -180,7 +181,7 @@ FHoudiniEngineCommands::OpenInHoudini()
 	UserTempPath = TEXT("\"") + UserTempPath + TEXT("\"");
 	// Then open the hip file in Houdini
 	FString LibHAPILocation = FHoudiniEngine::Get().GetLibHAPILocation();
-	FString HoudiniLocation = LibHAPILocation + TEXT("//houdini");
+	FString HoudiniLocation = LibHAPILocation + TEXT("//") + GetDefault<UHoudiniRuntimeSettings>()->HoudiniExeFileName;
 	FPlatformProcess::CreateProc(
 		*HoudiniLocation,
 		*UserTempPath,
@@ -955,7 +956,7 @@ FHoudiniEngineCommands::OpenSessionSync()
 	{
 		// Start houdini with the -hess commandline args
 		FString LibHAPILocation = FHoudiniEngine::Get().GetLibHAPILocation();
-		FString HoudiniLocation = LibHAPILocation + TEXT("//houdini");
+		FString HoudiniLocation = LibHAPILocation + TEXT("//") + GetDefault<UHoudiniRuntimeSettings>()->HoudiniExeFileName;
 		FProcHandle HESSHandle = FPlatformProcess::CreateProc(
 			*HoudiniLocation,
 			*SessionSyncArgs,

--- a/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.cpp
@@ -68,6 +68,7 @@ UHoudiniRuntimeSettings::UHoudiniRuntimeSettings( const FObjectInitializer & Obj
 	// Custom Houdini location.
 	bUseCustomHoudiniLocation = false;
 	CustomHoudiniLocation.Path = TEXT("");
+	HoudiniExeFileName = TEXT("houdini");
 
 	// Arguments for HAPI_Initialize
 	CookingThreadStackSize = -1;

--- a/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniRuntimeSettings.h
@@ -240,6 +240,10 @@ protected:
 		// Custom Houdini location (where HAPI library is located).
 		UPROPERTY(GlobalConfig, EditAnywhere, Category = HoudiniLocation, Meta = (DisplayName = "Custom Houdini location"))
 		FDirectoryPath CustomHoudiniLocation;
+	
+		// If you are using houdini indie in steam, set to hindie.steam
+		UPROPERTY(GlobalConfig, EditAnywhere, Category="HoudiniLocation", Meta = (DisplayName = "houdini.exe file name"), AdvancedDisplay)
+		FString HoudiniExeFileName;
 
 		//-------------------------------------------------------------------------------------------------------------
 		// HAPI_Initialize


### PR DESCRIPTION
default exe file name "houdini" is invalid when using Houdini Indie on steam. so I add a config to makesure  i can change it to fit  "hindie.steam" 