### PR TITLE
Fix Houdini Spline visualization rotation and scale error

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniSplineComponentVisualizer.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniSplineComponentVisualizer.cpp
@@ -207,7 +207,7 @@ FHoudiniSplineComponentVisualizer::DrawVisualization(
 		for (int32 Index = 0; Index < DisplayPoints.Num(); ++Index) 
 		{
 			const FVector & CurrentPoint = DisplayPoints[Index];
-			FVector CurrentPosition = CurrentPoint + HoudiniSplineComponentTransform.GetLocation();
+			FVector CurrentPosition = HoudiniSplineComponentTransform.TransformPosition(CurrentPoint);
 			//CurrentPosition = CurrentPoint;
 			if (Index > 0) 
 			{


### PR DESCRIPTION
When rotate or scale the hda actor, Houdini Spline doesn't respond to it. Only the points moved but the line segment doesn't.