### PR TITLE
Fixed warning about uninitialized property bAutoBakedSinceLastLoad

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniPDGAssetLink.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniPDGAssetLink.cpp
@@ -87,6 +87,7 @@ FTOPWorkResultObject::FTOPWorkResultObject()
 	FilePath = FString();
 	State = EPDGWorkResultState::None;
 	WorkItemResultInfoIndex = INDEX_NONE;
+	bAutoBakedSinceLastLoad = false;
 }
 
 FTOPWorkResultObject::~FTOPWorkResultObject()


### PR DESCRIPTION
Just a fix for a build time warning:
`FTOPWorkResultObject::bAutoBakedSinceLastLoad is not initialized properly. Module:HoudiniEngineRuntime File:Private/HoudiniPDGAssetLink.h`