### PR TITLE
fix: Casing of PlatformFileManager.h

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
@@ -51,7 +51,7 @@
 #include "EditorSupportDelegates.h"
 #include "FileHelpers.h"
 #include "LandscapeInfo.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "HAL/FileManager.h"
 #include "Engine/WorldComposition.h"
 #include "Modules/ModuleManager.h"

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
@@ -53,7 +53,7 @@
 
 #include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
 #include "AssetRegistryModule.h"

--- a/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
@@ -13,7 +13,7 @@
 #include "LevelEditor.h"
 #include "AssetRegistryModule.h"
 #include "Core/Public/HAL/FileManager.h"
-#include "Core/Public/HAL/PlatformFilemanager.h"
+#include "Core/Public/HAL/PlatformFileManager.h"
 #include "Editor/EditorPerformanceSettings.h"
 #include "Engine/Selection.h"
 #include "Interfaces/IMainFrameModule.h"


### PR DESCRIPTION
## Problem
Builds on Ubuntu 20.04, UE 5 EA fail because of incorrectly cased `PlatformFilemanager.h`.

```sh
$ make UnrealEditor
...
...
In file included from /home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Intermediate/Build/Linux/B4D820EA/UnrealEditor/Development/HoudiniEngineEditor/Module.HoudiniEngineEditor.3_of_3.cpp:15:
/home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp:16:10: fatal error: 'Core/Public/HAL/PlatformFilemanager.h' file not found
#include "Core/Public/HAL/PlatformFilemanager.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
In file included from /home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Intermediate/Build/Linux/B4D820EA/UnrealEditor/Development/HoudiniEngineEditor/Module.HoudiniEngineEditor.1_of_3.cpp:10:
/home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp:56:10: fatal error: 'HAL/PlatformFilemanager.h' file not found
#include "HAL/PlatformFilemanager.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
In file included from /home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Intermediate/Build/Linux/B4D820EA/UnrealEditor/Development/HoudiniEngine/Module.HoudiniEngine.3_of_5.cpp:4:
/home/subir/UnrealEngine-5.0.0-early-access-2/Engine/Plugins/HoudiniEngine/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp:54:10: fatal error: 'HAL/PlatformFilemanager.h' file not found
#include "HAL/PlatformFilemanager.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [Makefile:1048: UnrealEditor] Error 6
```
## Solution
Build succeeds after renaming `PlatformFilemanager.h` to `PlatformFileManager.h`.

Tested with **UnrealEngine-5.0.0-early-access-2** on **Ubuntu 20.04**