### PR TITLE
Simplified getting the asset state as string, removed unused helpers

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.h
@@ -167,7 +167,7 @@ public:
 	UHoudiniAsset * GetHoudiniAsset() const;
 	int32 GetAssetId() const { return AssetId; };
 	EHoudiniAssetState GetAssetState() const { return AssetState; };
-	FString GetAssetStateAsString() const { return FHoudiniEngineRuntimeUtils::EnumToString(TEXT("EHoudiniAssetState"), GetAssetState()); };
+	FString GetAssetStateAsString() const { return UEnum::GetValueAsString(GetAssetState()); };
 	EHoudiniAssetStateResult GetAssetStateResult() const { return AssetStateResult; };
 	FGuid GetHapiGUID() const { return HapiGUID; };
 	FString GetHapiAssetName() const { return HapiAssetName; };

--- a/Source/HoudiniEngineRuntime/Private/HoudiniEngineRuntimeUtils.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniEngineRuntimeUtils.h
@@ -162,25 +162,6 @@ struct HOUDINIENGINERUNTIME_API FHoudiniEngineRuntimeUtils
 		static int32 SafeDeleteObjects(TArray<UObject*>& InObjectsToDelete, TArray<UObject*>* OutObjectsNotDeleted=nullptr);
 
 		// -------------------------------------------------
-		// Type utilities
-		// -------------------------------------------------
-
-		// Taken from here: https://answers.unrealengine.com/questions/330496/conversion-of-enum-to-string.html
-		// Return the string representation of an enum value.
-		template<typename T>
-		static FString EnumToString(const FString& EnumName, const T Value)
-		{
-			UEnum* Enum = FindObject<UEnum>(ANY_PACKAGE, *EnumName);
-			return *(Enum ? Enum->GetNameStringByValue(static_cast<uint8>(Value)) : "null");
-		}
-
-		template<typename T>
-		static FString EnumToString(const T Value)
-		{
-			return UEnum::GetValueAsString(Value);
-		}
-
-		// -------------------------------------------------
 		// Blueprint utilities
 		// -------------------------------------------------
 #if WITH_EDITOR


### PR DESCRIPTION
`EnumToString` was failing to compile on Linux, and these helper functions seem surplus to requirements - they were only used in one place, and it seems neater just to call `UEnum::GetValueAsString` directly.

This is the Linux build error we hit:
```
/build/ue4/Engine/Plugins/Runtime/HoudiniEngine/Source/HoudiniEngineRuntime/Private/HoudiniEngineRuntimeUtils.h:173:18: error: no matching function for call to 'FindObject'
                        UEnum* Enum = FindObject<UEnum>(ANY_PACKAGE, *EnumName);
                                      ^~~~~~~~~~~~~~~~~
/build/ue4/Engine/Source/Runtime/CoreUObject/Public/UObject/UObjectGlobals.h:1255:11: note: candidate function template not viable: cannot convert argument of incomplete type 'UPackage *' to 'UObject *' for 1st argument
```