### PR TITLE
Fixed Linux build error due to case issue for UE4

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
@@ -51,7 +51,7 @@
 #include "EditorSupportDelegates.h"
 #include "FileHelpers.h"
 #include "LandscapeInfo.h"
-#include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformFilemanager.h"
 #include "HAL/FileManager.h"
 #include "Engine/WorldComposition.h"
 #include "Modules/ModuleManager.h"

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
@@ -53,7 +53,7 @@
 
 #include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
-#include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformFilemanager.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
 #include "AssetRegistryModule.h"

--- a/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
@@ -12,7 +12,7 @@
 #include "LevelEditor.h"
 #include "AssetRegistryModule.h"
 #include "Core/Public/HAL/FileManager.h"
-#include "Core/Public/HAL/PlatformFileManager.h"
+#include "Core/Public/HAL/PlatformFilemanager.h"
 #include "Editor/EditorPerformanceSettings.h"
 #include "Engine/Selection.h"
 #include "Interfaces/IMainFrameModule.h"


### PR DESCRIPTION
In UE5 the included header has a name: `PlatformFileManager.h` but in UE4: `PlatformFilemanager.h`
Linux is case sensetive and at build with UE4.26 get `fatal error: 'HAL/PlatformFileManager.h' file not found`