### PR TITLE
Remove IsPendingKill() with IsValidChecked()

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIInputTypes.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIInputTypes.cpp
@@ -111,8 +111,7 @@ UHoudiniPublicAPIInput::PopulateFromHoudiniInput(UHoudiniInput const* const InIn
 
 			UObject* NewInputObject = ConvertInternalInputObject(SrcInputObject->GetObject());
 			
-			// TODO: PENDINGKILL replacement ?
-			if (NewInputObject && NewInputObject->IsPendingKill())
+			if (NewInputObject && !IsValidChecked(NewInputObject))
 			{
 				SetErrorMessage(FString::Printf(
 					TEXT("One of the input objects is non-null but pending kill/invalid.")));


### PR DESCRIPTION
IsPendingKill is deprecated, IsValidChecked() is the wrapper for that. If NewInputObject is non-null but IsValidChecked() fails then the object is pending kill/invalid.