### PR TITLE
Add LINUX_BUILD Definition to support linux without destructing others

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,5 @@ However, the Houdini Digital Assets themselves (the HDA files), that were create
 01. You should now be able to import Houdini Digital Assets (HDA) `.otl` or `.hda` files or drag and drop them into the `Content Browser`.
 01. Once you have an HDA in the `Content Browser` you should be able to drag it into the Editor viewport. This will spawn a new Houdini Asset Actor. Geometry cooking will be done in a separate thread and geometry will be displayed once the cooking is complete. At this point you will be able to see asset parameters in the `Details` pane. Modifying any of the parameters will force the asset to recook and possibly update its geometry.
 
-
+# Building on Linux
+If you are using `RunUAT.sh` on Linux distributions, you should add `-Definition=LINUX_BUILD` to your command.

--- a/Source/HoudiniEngine/Private/HoudiniEngine.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngine.cpp
@@ -43,7 +43,12 @@
 #include "Engine/StaticMesh.h"
 #include "Materials/Material.h"
 #include "ISettingsModule.h"
-#include "HAL/PlatformFilemanager.h"
+#ifdef LINUX_BUILD
+  #include "HAL/PlatformFileManager.h"
+#else
+  #include "HAL/PlatformFilemanager.h"
+#endif
+
 #include "Async/Async.h"
 #include "Logging/LogMacros.h"
 

--- a/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniOutputTranslator.cpp
@@ -51,7 +51,11 @@
 #include "EditorSupportDelegates.h"
 #include "FileHelpers.h"
 #include "LandscapeInfo.h"
-#include "HAL/PlatformFilemanager.h"
+#ifdef LINUX_BUILD
+  #include "HAL/PlatformFileManager.h"
+else
+  #include "HAL/PlatformFilemanager.h"
+#endif
 #include "HAL/FileManager.h"
 #include "Engine/WorldComposition.h"
 #include "Modules/ModuleManager.h"

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
@@ -53,7 +53,11 @@
 
 #include "Modules/ModuleManager.h"
 #include "Interfaces/IPluginManager.h"
-#include "HAL/PlatformFilemanager.h"
+#ifdef LINUX_BUILD
+  #include "HAL/PlatformFileManager.h"
+else
+  #include "HAL/PlatformFilemanager.h"
+#endif
 #include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
 #include "AssetRegistryModule.h"

--- a/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
@@ -12,7 +12,11 @@
 #include "LevelEditor.h"
 #include "AssetRegistryModule.h"
 #include "Core/Public/HAL/FileManager.h"
-#include "Core/Public/HAL/PlatformFilemanager.h"
+#ifdef LINUX_BUILD
+  #include "Core/Public/HAL/PlatformFileManager.h"
+#else
+  #include "Core/Public/HAL/PlatformFilemanager.h"
+#endif
 #include "Editor/EditorPerformanceSettings.h"
 #include "Engine/Selection.h"
 #include "Interfaces/IMainFrameModule.h"


### PR DESCRIPTION
## Previous Discussions

I've read that Pull Request #149 in advance, and I thought that changing variable casing without deriving cases with any pre-processor check can cause potential build problem on other platforms.

## Solution
I would like to append LINUX_BUILD macro check to distinguish Linux platform with others.
In most of the cases, Module installation on Linux, is using manual script called RunUAT.sh; so developers who are working on Linux should have been searched for script usage.
it is valid to conclude that the easiest solution to guide Linux Installation is to show the exact flag that is needed for proper builds.